### PR TITLE
Call fullHdLow results instead of fullHd results

### DIFF
--- a/fall_guys_bot.py
+++ b/fall_guys_bot.py
@@ -214,7 +214,7 @@ class FullHDLow:
                 print("ok")
                 time.sleep(1)
                 pyautogui.press("space")
-                e.results()
+                o.results()
                 break
 
     @staticmethod


### PR DESCRIPTION
In the FullHDLow.ok method the FullHD.results method is called which can lead to issues when using the "1080 low"-resolution mode.